### PR TITLE
add connection pool options to pg connection

### DIFF
--- a/lib/stores/postgres/connection.js
+++ b/lib/stores/postgres/connection.js
@@ -10,10 +10,9 @@ pg.types.setTypeParser(20, 'text', parseInt)
  */
 exports.store = {
   mixinCallback: function(){
-
-    this.connection = Knex({
+    var connectionConfig = {
       dialect: 'pg',
-      connection: {
+      connection: this.config.connection || {
         host     : this.config.host,
         port     : this.config.port,
         user     : this.config.user || this.config.username,
@@ -21,7 +20,10 @@ exports.store = {
         database : this.config.database,
         charset  : this.config.charset
       }
-    });
+    }
+    if(this.config.pool) connectionConfig['pool'] = this.config.pool;
+
+    this.connection = Knex(connectionConfig);
   },
 
   close: function(callback){


### PR DESCRIPTION
This pull request gives your users fine grained control over their database connection if they are using PostgreSQL including the ability to connect with a PG connection string