### PR TITLE
Cleanup docs

### DIFF
--- a/docs/definition.md
+++ b/docs/definition.md
@@ -215,7 +215,7 @@ A relation - except for a polymorphic relations - always needs a target model. T
 
 The relation will be initialized after the target model is ready - to automatically get the primary and foreign key. The default for the foreign key is `<model_name>_<primary_key>` - all lower case! You could manually set the `from` and `to` key, if you need.
 
-The `name` of the relation is a string and could be anything you like. If you use the plural oder singular version of an existing model name, OPENRECORD will automatically detect it and will set most of the options for you.  
+The `name` of the relation is a string and could be anything you like. If you use the plural or singular version of an existing model name, OPENRECORD will automatically detect it and will set most of the options for you.  
 The `options` parameter is optional, if it can autodetect your target model. Otherwise you need to privide an object with the following config options:
 * **model**: The target model name as a string
 * **store**: Optional store `name`. Only needed for cross store relations!
@@ -227,12 +227,13 @@ The `options` parameter is optional, if it can autodetect your target model. Oth
 * **conditions**: Optional `conditions` object (See [Query](./query.md#with-conditions))
 * **dependent**: What should happen with the related record after a record of this model will be deleted. Valid values are: `destroy`, `delete`, `nullify` or null. (Default null)
 * **autoSave**: Automatically save loaded or new related records (See [save](./modify#save) and [setup](./setup.md))
+
 ### hasMany(name[, options])
 The target model contains the primary key of this model
 
 ```js
 // models/User.js
-this.hasMany('posts', {foreign_key: 'author_id', autoSave: true})
+this.hasMany('posts', {to: 'author_id', autoSave: true})
 ```
 
 ### hasOne(name[, options])

--- a/docs/modify.md
+++ b/docs/modify.md
@@ -40,7 +40,7 @@ console.log(user.id)
 After you've [loaded an existing record](./query.md) you can modify it.
 
 ```js
-const user = User.find(2)
+const user = await User.find(2)
 user.last_name = 'Waldmann'
 await user.save()
 ```
@@ -68,7 +68,7 @@ To save a record back to your datastore, just call `save()`.
 OPENRECORD will automatically [validate](#validate) your record and checks for [changes](#haschanges). It will only update your datastore if something has changed.  
 
 ```js
-const user = User.find(2)
+const user = await User.find(2)
 user.last_name = 'Waldmann'
 await user.save()
 await user.save() // will be ignored!
@@ -77,7 +77,7 @@ await user.save() // will be ignored!
 If you call `save()` it will also automatically check all loaded or new relations and save them as well, if you have activated `autoSave` in your [relation defintion](./definition#relations)!
 
 ```js
-const user = User.find(2)
+const user = await User.find(2)
 user.posts.new({title: 'Awesome'})
 await user.save() // will only create the new post, because user has not changed!
 ```
@@ -100,7 +100,7 @@ You can use almost any [query](./query.md) method to filter your records.
 To manually check if a record has changes
 
 ```js
-const user = User.find(2)
+const user = await User.find(2)
 user.last_name = 'Waldmann'
 console.log(user.hasChanges()) // outputs `true`
 ```
@@ -110,7 +110,7 @@ console.log(user.hasChanges()) // outputs `true`
 To get all changes
 
 ```js
-const user = User.find(2)
+const user = await User.find(2)
 user.last_name = 'Waldmann'
 console.log(user.getChanges()) // outputs `{last_name: ['Old Value', 'Waldmann']}`
 ```
@@ -120,7 +120,7 @@ console.log(user.getChanges()) // outputs `{last_name: ['Old Value', 'Waldmann']
 Undo all unsaved changes.
 
 ```js
-const user = User.find(2)
+const user = await User.find(2)
 user.last_name = 'Waldmann'
 user.resetChanges()
 console.log(user.hasChanges()) // outputs `false`
@@ -131,7 +131,7 @@ console.log(user.hasChanges()) // outputs `false`
 To manually validate a record
 
 ```js
-const user = User.find(2)
+const user = await User.find(2)
 user.last_name = 'Waldmann'
 const valid = await user.isValid()
 console.log(valid) // outputs `true`
@@ -144,7 +144,7 @@ console.log(valid) // outputs `true`
 To remove a record from your datastore use `destroy()`
 
 ```js
-const user = User.find(2)
+const user = await User.find(2)
 await user.destroy()
 ```
 

--- a/docs/query.md
+++ b/docs/query.md
@@ -79,7 +79,7 @@ User.where(['login = :login', {login: 'phil'}])
 
 If you have [relations](./definition.md#relations) defined, here is an example how to use them:
 ```js
-const threads = Thread.where({sticky: true}).include('posts')
+const threads = await Thread.where({sticky: true}).include('posts')
 console.log(threads[0].posts)
 ```
 
@@ -98,7 +98,7 @@ We could use `include()` to preload these relations the following way:
 Thread.include(['posts', 'author'])
 Thread.include({posts: {author: 'last_post'}})
 // or both queries combined
-Thread.include([{posts: {author: 'last_post'}}, 'author])
+Thread.include([{posts: {author: 'last_post'}}, 'author'])
 ```
 
 Filtering these relations could be done with `where` as well.  
@@ -216,7 +216,7 @@ You could change that via the `select()` method.
 ### select(field ...)
 Will only select the given fields.  
 ```js
-const user = User.find(1).select('login')
+const user = await User.find(1).select('login')
 // only user.login will be populated. all the other field will be null
 ```
 


### PR DESCRIPTION
Apart from these changes, i have noticed that when we have
```js
const Store = require('openrecord/store/sqlite3')
```
`Store.BaseModel` is `undefined`. Although when I create the `store = new Store(...)`, `store.BaseModel` exist on the instance. I don't know if this is intended and we just need to update the docs, or it's a bug.

