### PR TITLE
update docsify config: `repo`

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -13,7 +13,7 @@
   <script>
     window.$docsify = {
       name: 'openrecord',
-      repo: 'git://github.com/PhilWaldmann/openrecord',
+      repo: 'PhilWaldmann/openrecord',
       loadSidebar: true,
       subMaxLevel: 2,
       auto2top: true,


### PR DESCRIPTION
https://github.com/PhilWaldmann/openrecord/blob/2acac32ebbcdfbd024d560e72bffa90ed7415f0d/docs/index.html#L14-L16

Using `git://*` will cause the following problems:

![image](https://user-images.githubusercontent.com/157338/39115947-b9561440-4715-11e8-9bb1-cad3fdf547be.png)
