### PR TITLE
Allow column params to be passed to knex

### DIFF
--- a/lib/stores/mysql/attributes.js
+++ b/lib/stores/mysql/attributes.js
@@ -19,6 +19,7 @@ exports.store = {
               primary: result[i].Key === 'PRI',
               notnull: result[i].Null !== 'YES',
               default: result[i].Default,
+              length: getMaxLength(result[i].Type),
               writable: !(
                 result[i].Key === 'PRI' && result[i].Extra === 'auto_increment'
               ) // set to false if primary and integer
@@ -36,6 +37,18 @@ exports.store = {
         return attributes
       })
   }
+}
+
+function getMaxLength(type) {
+  var len = type.match(/\((\d+)\)/)
+  if (len) {
+    len = parseInt(len[1])
+
+    if (len > 1) {
+      return len
+    }
+  }
+  return null
 }
 
 function simplifiedType(type) {

--- a/lib/stores/oracle/attributes.js
+++ b/lib/stores/oracle/attributes.js
@@ -32,6 +32,7 @@ exports.store = {
               primary: result[i].CONSTRAINT_TYPE === 'P',
               notnull: result[i].NULLABLE !== 'Y',
               default: null, // result[i].Default,
+              length: getMaxLength(attr.DATA_TYPE),
               writable: !(
                 result[i].CONSTRAINT_TYPE === 'P' && result[i].NULLABLE === 'N'
               ) // set to false if primary and not null
@@ -48,6 +49,18 @@ exports.store = {
         return attributes
       })
   }
+}
+
+function getMaxLength(type) {
+  var len = type.match(/\((\d+)\)/)
+  if (len) {
+    len = parseInt(len[1])
+
+    if (len > 1) {
+      return len
+    }
+  }
+  return null
 }
 
 function simplifiedType(type, precision, scale) {

--- a/lib/stores/postgres/attributes.js
+++ b/lib/stores/postgres/attributes.js
@@ -201,6 +201,7 @@ exports.store = {
               primary: primary,
               notnull: attribute.attnotnull,
               default: extractValueFromDefault(attribute.pg_get_expr),
+              length: getMaxLength(attribute.format_type),
               writable: !(primary && hasDefaultValue) // set to false if primary with default value
             },
             validations: extractValidations(attribute)
@@ -242,7 +243,7 @@ exports.store = {
                 attrDef.type_attributes = attributes
                 return attrDef
               })
-              .catch(function(){
+              .catch(function() {
                 // ignore error and use default type `string`
                 attrDef.type = 'string'
                 return attrDef
@@ -254,6 +255,18 @@ exports.store = {
       )
     })
   }
+}
+
+function getMaxLength(type) {
+  var len = type.match(/\((\d+)\)/)
+  if (len) {
+    len = parseInt(len[1])
+
+    if (len > 1) {
+      return len
+    }
+  }
+  return null
 }
 
 function simplifiedType(type, attribute) {
@@ -274,13 +287,9 @@ function extractValidations(attribute) {
   var validations = []
 
   // max length validation
-  var len = attribute.format_type.match(/\((.+)\)/)
+  var len = getMaxLength(attribute.format_type)
   if (len) {
-    len = parseInt(len[1])
-
-    if (len > 1) {
-      validations.push({ name: 'validatesLengthOf', args: [len] })
-    }
+    validations.push({ name: 'validatesLengthOf', args: [len] })
   }
 
   // not null

--- a/lib/stores/sql/migrations/data_types.js
+++ b/lib/stores/sql/migrations/data_types.js
@@ -98,7 +98,7 @@ exports.migration = {
   },
 
   // not a data-type, but fits nicely with createTable
-  unique: function () {
+  unique: function() {
     this._addColumnTypeFn('unique').apply(this, arguments)
   }
 }

--- a/lib/stores/sql/migrations/data_types.js
+++ b/lib/stores/sql/migrations/data_types.js
@@ -26,6 +26,12 @@ exports.migration = {
     var self = this
     var options = typeof args[args.length - 1] === 'object' ? args.pop() || {} : {}
 
+    // use trailing '!' on field name to indicate 'not null'
+    if (name[name.length - 1] === '!') {
+      name = name.slice(0, -1)
+      options.null = false
+    }
+
     if (options.primary) self.primary.push(name)
 
     return function(table) {

--- a/lib/stores/sql/migrations/data_types.js
+++ b/lib/stores/sql/migrations/data_types.js
@@ -79,5 +79,15 @@ exports.migration = {
 
   type: function(type, ...args) {
     this._addColumnTypeFn(type).call(this, ...args)
+  },
+
+  // not a data-type, but fits nicely with createTable
+  index: function() {
+    this._addColumnTypeFn('index').apply(this, arguments)
+  },
+
+  // not a data-type, but fits nicely with createTable
+  unique: function () {
+    this._addColumnTypeFn('unique').apply(this, arguments)
   }
 }

--- a/lib/stores/sql/migrations/data_types.js
+++ b/lib/stores/sql/migrations/data_types.js
@@ -87,6 +87,11 @@ exports.migration = {
     this._addColumnTypeFn(type).call(this, ...args)
   },
 
+  // used to reference another table
+  id: function() {
+    this._addColumnTypeFn('integer').apply(this, arguments)
+  },
+
   // not a data-type, but fits nicely with createTable
   index: function() {
     this._addColumnTypeFn('index').apply(this, arguments)

--- a/lib/stores/sql/migrations/data_types.js
+++ b/lib/stores/sql/migrations/data_types.js
@@ -24,7 +24,7 @@ exports.migration = {
 
   _defineColumnTypeFn: function(type, name, ...args) {
     var self = this
-    var options = typeof args[args.length - 1] === 'object' ? args.pop() : {}
+    var options = typeof args[args.length - 1] === 'object' ? args.pop() || {} : {}
 
     if (options.primary) self.primary.push(name)
 

--- a/lib/stores/sql/migrations/data_types.js
+++ b/lib/stores/sql/migrations/data_types.js
@@ -50,18 +50,17 @@ exports.migration = {
 
   _addColumnTypeFn: function(type) {
     var self = this
-    return function(table, name, options) {
-      if (typeof table === 'string' && typeof name === 'string') {
-        options = options || {}
+
+    return function(...args) {
+      if (typeof args[0] === 'string' && typeof args[1] === 'string') {
+        var table = args.shift()
 
         // add column to existing table
-        self.addColumn(table, self._defineColumnTypeFn(type, name, options))
+        self.addColumn(table, self._defineColumnTypeFn(type, ...args))
       } else {
-        options = name || {}
-        name = table
 
         // inside a createTable()
-        self.fields.push(self._defineColumnTypeFn(type, name, options))
+        self.fields.push(self._defineColumnTypeFn(type, ...args))
       }
     }
   },

--- a/lib/stores/sql/migrations/data_types.js
+++ b/lib/stores/sql/migrations/data_types.js
@@ -77,7 +77,7 @@ exports.migration = {
     this._addColumnTypeFn('enum').apply(this, arguments)
   },
 
-  type: function(type, name, options) {
-    this._addColumnTypeFn(type).call(this, name, options)
+  type: function(type, ...args) {
+    this._addColumnTypeFn(type).call(this, ...args)
   }
 }

--- a/lib/stores/sql/migrations/data_types.js
+++ b/lib/stores/sql/migrations/data_types.js
@@ -22,8 +22,9 @@ exports.migration = {
     }
   },
 
-  _defineColumnTypeFn: function(type, name, options) {
+  _defineColumnTypeFn: function(type, name, ...args) {
     var self = this
+    var options = typeof args[args.length - 1] === 'object' ? args.pop() : {}
 
     if (options.primary) self.primary.push(name)
 
@@ -38,7 +39,7 @@ exports.migration = {
       if (typeof options.custom === 'function') {
         column = options.custom(table)
       } else if (typeof fn === 'function') {
-        column = fn.call(table, name)
+        column = fn.call(table, name, ...args)
       } else {
         column = table.specificType(name, type)
       }

--- a/lib/stores/sqlite3/attributes.js
+++ b/lib/stores/sqlite3/attributes.js
@@ -20,6 +20,7 @@ exports.store = {
               primary: result[i].pk !== 0,
               notnull: result[i].notnull === 1,
               default: _default,
+              length: getMaxLength(result[i].type),
               writable: !(
                 result[i].pk !== 0 && result[i].type.toLowerCase() === 'integer'
               ) // set to false if primary and integer
@@ -36,6 +37,18 @@ exports.store = {
         return attributes
       })
   }
+}
+
+function getMaxLength(type) {
+  var len = type.match(/\((\d+)\)/)
+  if (len) {
+    len = parseInt(len[1])
+
+    if (len > 1) {
+      return len
+    }
+  }
+  return null
 }
 
 function simplifiedType(type) {

--- a/test/fixtures/cache/mysql.json
+++ b/test/fixtures/cache/mysql.json
@@ -6,6 +6,7 @@
         "type": "integer",
         "options": {
           "description": "",
+          "length": 20,
           "persistent": true,
           "primary": true,
           "notnull": true,
@@ -19,6 +20,7 @@
         "type": "string",
         "options": {
           "description": "",
+          "length": null,
           "persistent": true,
           "primary": false,
           "notnull": false,
@@ -32,6 +34,7 @@
         "type": "string",
         "options": {
           "description": "",
+          "length": null,
           "persistent": true,
           "primary": false,
           "notnull": false,
@@ -49,6 +52,7 @@
         "type": "integer",
         "options": {
           "description": "",
+          "length": 20,
           "persistent": true,
           "primary": true,
           "notnull": true,
@@ -62,6 +66,7 @@
         "type": "integer",
         "options": {
           "description": "",
+          "length": 11,
           "persistent": true,
           "primary": false,
           "notnull": false,
@@ -75,6 +80,7 @@
         "type": "integer",
         "options": {
           "description": "",
+          "length": 11,
           "persistent": true,
           "primary": false,
           "notnull": false,
@@ -88,6 +94,7 @@
         "type": "string",
         "options": {
           "description": "",
+          "length": null,
           "persistent": true,
           "primary": false,
           "notnull": false,

--- a/test/fixtures/cache/oracle.json
+++ b/test/fixtures/cache/oracle.json
@@ -6,6 +6,7 @@
         "type": "integer",
         "options": {
           "description": null,
+          "length": null,
           "persistent": true,
           "primary": true,
           "notnull": true,
@@ -19,6 +20,7 @@
         "type": "string",
         "options": {
           "description": null,
+          "length": null,
           "persistent": true,
           "primary": false,
           "notnull": false,
@@ -32,6 +34,7 @@
         "type": "string",
         "options": {
           "description": null,
+          "length": null,
           "persistent": true,
           "primary": false,
           "notnull": false,
@@ -49,6 +52,7 @@
         "type": "integer",
         "options": {
           "description": null,
+          "length": null,
           "persistent": true,
           "primary": true,
           "notnull": true,
@@ -62,6 +66,7 @@
         "type": "integer",
         "options": {
           "description": null,
+          "length": null,
           "persistent": true,
           "primary": false,
           "notnull": false,
@@ -75,6 +80,7 @@
         "type": "integer",
         "options": {
           "description": null,
+          "length": null,
           "persistent": true,
           "primary": false,
           "notnull": false,
@@ -88,6 +94,7 @@
         "type": "string",
         "options": {
           "description": null,
+          "length": null,
           "persistent": true,
           "primary": false,
           "notnull": false,

--- a/test/fixtures/cache/postgres.json
+++ b/test/fixtures/cache/postgres.json
@@ -6,6 +6,7 @@
         "type": "integer",
         "options": {
           "description": null,
+          "length": null,
           "persistent": true,
           "primary": true,
           "notnull": true,
@@ -19,6 +20,7 @@
         "type": "string",
         "options": {
           "description": null,
+          "length": null,
           "persistent": true,
           "primary": false,
           "notnull": true,
@@ -37,6 +39,7 @@
         "type": "string",
         "options": {
           "description": null,
+          "length": null,
           "persistent": true,
           "primary": false,
           "notnull": false,
@@ -54,6 +57,7 @@
         "type": "integer",
         "options": {
           "description": null,
+          "length": null,
           "persistent": true,
           "primary": true,
           "notnull": true,
@@ -67,6 +71,7 @@
         "type": "integer",
         "options": {
           "description": null,
+          "length": null,
           "persistent": true,
           "primary": false,
           "notnull": false,
@@ -80,6 +85,7 @@
         "type": "integer",
         "options": {
           "description": null,
+          "length": null,
           "persistent": true,
           "primary": false,
           "notnull": false,
@@ -93,6 +99,7 @@
         "type": "string",
         "options": {
           "description": null,
+          "length": null,
           "persistent": true,
           "primary": false,
           "notnull": false,
@@ -111,6 +118,7 @@
         "type": "integer",
         "options": {
           "description": null,
+          "length": null,
           "persistent": true,
           "primary": true,
           "notnull": true,
@@ -124,6 +132,7 @@
         "type": "composite",
         "options": {
           "description": null,
+          "length": null,
           "persistent": true,
           "primary": false,
           "notnull": false,
@@ -138,6 +147,7 @@
             "type": "integer",
             "options": {
               "description": null,
+              "length": null,
               "persistent": true,
               "primary": false,
               "notnull": false,
@@ -151,6 +161,7 @@
             "type": "string",
             "options": {
               "description": null,
+              "length": null,
               "persistent": true,
               "primary": false,
               "notnull": false,
@@ -166,6 +177,7 @@
         "type": "string",
         "options": {
           "description": null,
+          "length": null,
           "persistent": true,
           "primary": false,
           "notnull": false,

--- a/test/fixtures/cache/sqlite3.json
+++ b/test/fixtures/cache/sqlite3.json
@@ -6,6 +6,7 @@
         "type": "integer",
         "options": {
           "description": null,
+          "length": null,
           "persistent": true,
           "primary": true,
           "notnull": false,
@@ -19,6 +20,7 @@
         "type": "string",
         "options": {
           "description": null,
+          "length": null,
           "persistent": true,
           "primary": false,
           "notnull": false,
@@ -32,6 +34,7 @@
         "type": "string",
         "options": {
           "description": null,
+          "length": null,
           "persistent": true,
           "primary": false,
           "notnull": false,
@@ -49,6 +52,7 @@
         "type": "integer",
         "options": {
           "description": null,
+          "length": null,
           "persistent": true,
           "primary": true,
           "notnull": false,
@@ -62,6 +66,7 @@
         "type": "integer",
         "options": {
           "description": null,
+          "length": null,
           "persistent": true,
           "primary": false,
           "notnull": false,
@@ -75,6 +80,7 @@
         "type": "integer",
         "options": {
           "description": null,
+          "length": null,
           "persistent": true,
           "primary": false,
           "notnull": false,
@@ -88,6 +94,7 @@
         "type": "string",
         "options": {
           "description": null,
+          "length": null,
           "persistent": true,
           "primary": false,
           "notnull": false,

--- a/test/fixtures/migrations/20190214220159_create_migration_helpers.js
+++ b/test/fixtures/migrations/20190214220159_create_migration_helpers.js
@@ -1,0 +1,13 @@
+module.exports = function () {
+  this.createTable('migration_helpers', function () {
+    this.string('string_attr', 42) // includes string len
+    this.string('string_attr_def', 69, { default: 'hrm' }) // adds default value
+    this.string('req_string_attr!', 13, { default: 'nice' }) // adds not null
+
+    this.id('foreign_id') // id is an integer
+    this.id('req_foreign_id!') // adds not null
+
+    this.index('string_attr') // adds index
+    this.unique('req_string_attr') // adds unique
+  })
+}

--- a/test/fixtures/migrations/20190214220159_create_migration_helpers.js
+++ b/test/fixtures/migrations/20190214220159_create_migration_helpers.js
@@ -1,12 +1,10 @@
-module.exports = function () {
-  this.createTable('migration_helpers', function () {
+module.exports = function() {
+  this.createTable('migration_helpers', function() {
     this.string('string_attr', 42) // includes string len
     this.string('string_attr_def', 69, { default: 'hrm' }) // adds default value
     this.string('req_string_attr!', 13, { default: 'nice' }) // adds not null
-
     this.id('foreign_id') // id is an integer
     this.id('req_foreign_id!') // adds not null
-
     this.index('string_attr') // adds index
     this.unique('req_string_attr') // adds unique
   })

--- a/test/sql/__shared/migration_helpers-test.js
+++ b/test/sql/__shared/migration_helpers-test.js
@@ -1,0 +1,65 @@
+var path = require('path')
+var Store = require('../../../store')
+
+module.exports = function(title, beforeFn, afterFn, storeConf) {
+  describe(title + ': Migration Helpers', function() {
+    var store
+
+    before(beforeFn)
+    after(function(next) {
+      afterFn(next, store)
+      process.exit(0)
+    })
+
+    before(function() {
+      storeConf.migrations = path.join(
+        __dirname,
+        '..',
+        '..',
+        'fixtures',
+        'migrations',
+        '*'
+      )
+      storeConf.plugins = require('../../../lib/base/dynamic_loading')
+
+      store = new Store(storeConf)
+
+      store.Model('MigrationHelper', function() {})
+    })
+
+    it('has the correct column attributes and indexes', function() {
+      return store.ready(function () {
+        var MigrationHelper = store.Model('MigrationHelper')
+
+        // DEFINITIONS:
+        // this.string('string_attr', 42) // includes string len
+        // this.string('string_attr_def', 69, { default: 'hrm' }) // adds default value
+        // this.string('req_string_attr!', 13, { default: 'nice' }) // adds not null
+        // this.id('foreign_id') // id is an integer
+        // this.id('req_foreign_id!') // adds not null
+        // this.index('string_attr') // adds index
+        // this.unique('req_string_attr') // adds unique
+
+        // TESTS: (how do I do the check the others???)
+        // * string_attr is string
+        //   string_attr length of 42
+        //   string_attr_def length of 69
+        //   string_attr_def default of 'hrm'
+        // * req_string_attr is not null
+        //   req_string_attr length of 13
+        //   req_string_attr default of 'nice'
+        // * foreign_id is integer
+        // * req_foreign_id is integer
+        // * req_foreign_id not null
+        //   index on string_attr
+        //   unique on req_string_attr
+
+        MigrationHelper.definition.attributes.string_attr.type.name.should.be.equal('string')
+        MigrationHelper.definition.attributes.req_string_attr.notnull.should.be.equal(true)
+        MigrationHelper.definition.attributes.foreign_id.type.name.should.be.equal('integer')
+        MigrationHelper.definition.attributes.req_foreign_id.type.name.should.be.equal('integer')
+        MigrationHelper.definition.attributes.req_foreign_id.notnull.should.be.equal(true)
+      })
+    })
+  })
+}

--- a/test/sql/__shared/migration_helpers-test.js
+++ b/test/sql/__shared/migration_helpers-test.js
@@ -8,7 +8,6 @@ module.exports = function(title, beforeFn, afterFn, storeConf) {
     before(beforeFn)
     after(function(next) {
       afterFn(next, store)
-      process.exit(0)
     })
 
     before(function() {
@@ -23,14 +22,14 @@ module.exports = function(title, beforeFn, afterFn, storeConf) {
       storeConf.plugins = require('../../../lib/base/dynamic_loading')
 
       store = new Store(storeConf)
-
+      store.Model('User', function() {}) // for the seeding
       store.Model('MigrationHelper', function() {})
     })
 
     it('has the correct column attributes and indexes', function() {
-      return store.ready(function () {
+      return store.ready(function() {
         var MigrationHelper = store.Model('MigrationHelper')
-
+        var attributes = MigrationHelper.definition.attributes
         // DEFINITIONS:
         // this.string('string_attr', 42) // includes string len
         // this.string('string_attr_def', 69, { default: 'hrm' }) // adds default value
@@ -42,23 +41,28 @@ module.exports = function(title, beforeFn, afterFn, storeConf) {
 
         // TESTS: (how do I do the check the others???)
         // * string_attr is string
-        //   string_attr length of 42
-        //   string_attr_def length of 69
-        //   string_attr_def default of 'hrm'
+        // * string_attr length of 42
+        // * string_attr_def length of 69
+        // * string_attr_def default of 'hrm'
         // * req_string_attr is not null
-        //   req_string_attr length of 13
-        //   req_string_attr default of 'nice'
+        // * req_string_attr length of 13
+        // * req_string_attr default of 'nice'
         // * foreign_id is integer
         // * req_foreign_id is integer
         // * req_foreign_id not null
         //   index on string_attr
         //   unique on req_string_attr
 
-        MigrationHelper.definition.attributes.string_attr.type.name.should.be.equal('string')
-        MigrationHelper.definition.attributes.req_string_attr.notnull.should.be.equal(true)
-        MigrationHelper.definition.attributes.foreign_id.type.name.should.be.equal('integer')
-        MigrationHelper.definition.attributes.req_foreign_id.type.name.should.be.equal('integer')
-        MigrationHelper.definition.attributes.req_foreign_id.notnull.should.be.equal(true)
+        attributes.string_attr.type.name.should.be.equal('string')
+        attributes.string_attr.length.should.be.equal(42)
+        attributes.string_attr_def.default.should.be.equal('hrm')
+        attributes.string_attr_def.length.should.be.equal(69)
+        attributes.req_string_attr.notnull.should.be.equal(true)
+        attributes.req_string_attr.default.should.be.equal('nice')
+        attributes.req_string_attr.length.should.be.equal(13)
+        attributes.foreign_id.type.name.should.be.equal('integer')
+        attributes.req_foreign_id.type.name.should.be.equal('integer')
+        attributes.req_foreign_id.notnull.should.be.equal(true)
       })
     })
   })

--- a/test/sql/mysql/run_shared-tests.js
+++ b/test/sql/mysql/run_shared-tests.js
@@ -183,6 +183,8 @@ testMYSQL('joins', [
   "INSERT INTO poly_things (member_id, member_type, user_id) VALUES (1, 'Post', 1), (1, 'Thread', 1), (2, 'Thread', 2), (1, 'Avatar', 2)"
 ])
 
+testMYSQL('migration_helpers', [])
+
 testMYSQL('migrations_fresh', [])
 
 testMYSQL('migrations', [

--- a/test/sql/oracle/run_shared-tests.js
+++ b/test/sql/oracle/run_shared-tests.js
@@ -44,7 +44,7 @@ if (process.env['ORACLE_HOME']) {
     'PRIMARY:posts:id',
     'CREATE TABLE "threads"("id" number(10), "user_id" INTEGER, "title" TEXT)',
     'PRIMARY:threads:id',
-    "INSERT INTO \"users\"(\"user_login\", \"secret_email_address\") VALUES('phil', 'phil@mail.com')",
+    'INSERT INTO "users"("user_login", "secret_email_address") VALUES(\'phil\', \'phil@mail.com\')',
     'INSERT INTO "posts"("user_id", "thread_id", "message") VALUES(1, 1, \'first message\'), (1, 1, \'second\'), (1, 2, \'third\'), (2, 1, \'michls post\')',
     'INSERT INTO "threads"("user_id", "title") VALUES(2, \'first thread\'), (1, \'second thread\')'
   ])
@@ -211,6 +211,7 @@ if (process.env['ORACLE_HOME']) {
   //   "INSERT INTO poly_things (member_id, member_type, user_id) VALUES (1, 'Post', 1), (1, 'Thread', 1), (2, 'Thread', 2), (1, 'Avatar', 2)"
   // ])
   //
+  // testOracle('migration_helpers', [])
   //
   // testOracle('migrations_fresh', [])
   //

--- a/test/sql/postgres/cache-test.js
+++ b/test/sql/postgres/cache-test.js
@@ -79,6 +79,7 @@ describe('Postgres: Cache', function() {
         type: 'string',
         options: {
           description: null,
+          length: null,
           persistent: true,
           primary: false,
           notnull: false,
@@ -102,6 +103,7 @@ describe('Postgres: Cache', function() {
         type: 'composite',
         options: {
           description: null,
+          length: null,
           persistent: true,
           primary: false,
           notnull: false,
@@ -116,6 +118,7 @@ describe('Postgres: Cache', function() {
             type: 'integer',
             options: {
               description: null,
+              length: null,
               persistent: true,
               primary: false,
               notnull: false,
@@ -129,6 +132,7 @@ describe('Postgres: Cache', function() {
             type: 'string',
             options: {
               description: null,
+              length: null,
               persistent: true,
               primary: false,
               notnull: false,

--- a/test/sql/postgres/run_shared-tests.js
+++ b/test/sql/postgres/run_shared-tests.js
@@ -178,6 +178,8 @@ testPG('joins', [
   "INSERT INTO poly_things (member_id, member_type, user_id) VALUES (1, 'Post', 1), (1, 'Thread', 1), (2, 'Thread', 2), (1, 'Avatar', 2)"
 ])
 
+testPG('migration_helpers', [])
+
 testPG('migrations_fresh', [])
 
 testPG('group', [

--- a/test/sql/sqlite3/runs_shared-tests.js
+++ b/test/sql/sqlite3/runs_shared-tests.js
@@ -183,6 +183,8 @@ testSQLite('joins', [
   'INSERT INTO poly_things (member_id, member_type) VALUES (1, "Post"), (1, "Thread"), (2, "Thread"), (1, "Avatar")'
 ])
 
+testSQLite('migration_helpers', [])
+
 testSQLite('migrations_fresh', [])
 
 testSQLite('migrations', [


### PR DESCRIPTION
This is needed to be able to pass params such as the length of a varchar column. Otherwise, the defaults of varchar(255), etc. will always be used.

<img width="960" alt="db bash 2019-02-14 03-11-52" src="https://user-images.githubusercontent.com/142875/52779945-67beb800-3006-11e9-9ee6-d49e46cd5eca.png">
